### PR TITLE
string.unpack comments/fixes

### DIFF
--- a/extras/analog_read.lua
+++ b/extras/analog_read.lua
@@ -40,10 +40,11 @@ local num_pins = 0
 local arduino_i2c = i2c.get_device(I2C_BUS, SLAVE_ADDR)
 arduino_i2c:set_retries(10)
 
-local function unpack_uint(b)
+local function unpack_int(b)
     if type(b) ~= 'table' or #b == 0 then return ERROR_VALUE end
     local packed_string = string.char(table.unpack(b))
-    local fmt = ('I%d'):format(#b)  -- unsigned integer of table size
+    -- see https://www.lua.org/manual/5.3/manual.html#6.4.2 for string.unpack format options
+    local fmt = ('i%d'):format(#b)  -- signed integer of table size
     local val = string.unpack(fmt, packed_string)
     return val
 end
@@ -69,9 +70,9 @@ function update()
     for idx = 0, num_pins - 1 do
         -- request to store analog pin value in I2C registers for given index
         arduino_i2c:write_register(SET_PIN_INDEX, idx)
-        -- now read the register data and collect its value as an unsigned integer
+        -- now read the register data and collect its value as an signed integer
         local data = read_register_data()
-        gcs:send_named_float('A' .. idx, unpack_uint(data))
+        gcs:send_named_float('A' .. idx, unpack_int(data))
     end
     return update, RUN_INTERVAL_MS
 end

--- a/extras/ds18b20.lua
+++ b/extras/ds18b20.lua
@@ -49,6 +49,7 @@ arduino_i2c:set_retries(10)
 local function unpack_double(b)
     if type(b) ~= 'table' or #b ~= 8 then return ERROR_VALUE end
     local packed_string = string.char(table.unpack(b))
+    -- see https://www.lua.org/manual/5.3/manual.html#6.4.2 for string.unpack format options
     local val = string.unpack('d', packed_string)
     return val
 end

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=I2C_Slave
-version=0.3.2
+version=0.3.3
 author=Yuri Rage
 maintainer=Yuri Rage
 sentence=Arduino Library to create a basic I2C slave device


### PR DESCRIPTION
analog_read example possibly sends a signed integer error value (-1), so the Lua script should handle unpacking the signed integer value. That was intentional in the initial commit as a good example and overlooked when refactoring to use native Lua functions for byte conversion.

This will release 0.3.3 (likely the final rapid-fire update after inclusion to the IDE library registries)