### PR TITLE
Update for alternate Pins for I2C and TwoWire object conflict

### DIFF
--- a/src/I2C_Slave.h
+++ b/src/I2C_Slave.h
@@ -45,6 +45,7 @@ class I2C_Slave {
     I2C_Slave();
     void begin();
     void begin(uint8_t);
+    void begin(uint8_t addr, uint32_t sda, uint32_t scl);
     uint32_t numErrors();
     size_t numRegisters();
     void onCommand(void (*)(uint8_t, uint8_t));


### PR DESCRIPTION
- Added pin assignment for I2C if alternate pins are used.
- Added new TwoWire object to overcome conflict with default object.
- Added function declaration in header.